### PR TITLE
Cache Video Asset List

### DIFF
--- a/app/videos/page.js
+++ b/app/videos/page.js
@@ -1,14 +1,17 @@
 import Link from 'next/link'
 import Mux from '@mux/mux-node'
+import { cache } from 'react'
 
 // Assumes you have your access token set in environment variables:
 // Access Token ID: process.env.MUX_TOKEN_ID
 // Access Token Secret: process.env.MUX_TOKEN_SECRET
 const { Video } = new Mux()
+const getAssets = cache(async () => {
+  return await Video.Assets.list()
+})
 
 export default async function VideosPage() {
-  const assets = await Video.Assets.list()
-
+  const assets = await getAssets()
   const videos = assets.map((asset) => {
     let title = 'Default Title'
     let description = 'Default description'


### PR DESCRIPTION
@refactornator et al

The React and Next team are encouraging users to wrap non-fetch api calls in `React.cache`. 

In our case, I believe that'll cache the results of this call between serverless function invocations.
More generally, if we were to abstract this function out into its own file and use it in multiple places within the app, that cache would be shared between all those places, scaling nicely.

This is my only piece of feedback on #6 though! Otherwise looks great!

When we want to introduce advanced functionality in part two of the workshop, we'll be able to abstract the data fetching and list into its own component and wrap it in Suspense so that we can get to the page before the list loads and see a nice loading state. Kinda like what you had with React Query.